### PR TITLE
abs v1.3.0

### DIFF
--- a/Binary_Modules/GetAllWifiDevices/GetAllWifiDevices.go
+++ b/Binary_Modules/GetAllWifiDevices/GetAllWifiDevices.go
@@ -4,7 +4,15 @@ import (
 	"fmt"
 	"os"
 	"github.com/Wifx/gonetworkmanager/v3"
+	"github.com/alexflint/go-arg"
 )
+
+const (
+	detail_delim = ","
+)
+var args struct {
+	Detailed bool
+}
 
 func if_err_log_and_die(err error){
 	if err != nil {
@@ -13,7 +21,24 @@ func if_err_log_and_die(err error){
 	}
 }
 
+func output_device_based_on_args(device gonetworkmanager.Device) error {
+	print_string := string(device.GetPath())
+
+	if args.Detailed {
+		ifname, err := device.GetPropertyInterface()
+		if err != nil {
+			return err
+		}
+		print_string += detail_delim
+		print_string += ifname
+	}
+	fmt.Println(print_string)
+	return nil
+}
+
 func main (){
+	arg.MustParse(&args)
+
 	nm, err := gonetworkmanager.NewNetworkManager()
 	if_err_log_and_die(err)
 
@@ -25,7 +50,7 @@ func main (){
 		if_err_log_and_die(err)
 
 		if device_type == gonetworkmanager.NmDeviceTypeWifi{
-			fmt.Println(devices[i].GetPath())
+			_ = output_device_based_on_args(devices[i])
 		}	
 	}
 }

--- a/Binary_Modules/GetAllWifiDevices/GetAllWifiDevices.go
+++ b/Binary_Modules/GetAllWifiDevices/GetAllWifiDevices.go
@@ -16,7 +16,7 @@ var args struct {
 
 func if_err_log_and_die(err error){
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }

--- a/Binary_Modules/GetAllWifiDevices/GetAllWifiDevices.go
+++ b/Binary_Modules/GetAllWifiDevices/GetAllWifiDevices.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-
 	"github.com/Wifx/gonetworkmanager/v3"
 )
 
@@ -27,8 +26,6 @@ func main (){
 
 		if device_type == gonetworkmanager.NmDeviceTypeWifi{
 			fmt.Println(devices[i].GetPath())
-		}
-		
+		}	
 	}
-
 }

--- a/Binary_Modules/GetAllWifiDevices/GetAllWifiDevices.go
+++ b/Binary_Modules/GetAllWifiDevices/GetAllWifiDevices.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Wifx/gonetworkmanager/v3"
+)
+
+func if_err_log_and_die(err error){
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+}
+
+func main (){
+	nm, err := gonetworkmanager.NewNetworkManager()
+	if_err_log_and_die(err)
+
+	devices, err := nm.GetAllDevices()
+	if_err_log_and_die(err)
+
+	for i := 0; i < len(devices); i++{
+		device_type, err := devices[i].GetPropertyDeviceType()
+		if_err_log_and_die(err)
+
+		if device_type == gonetworkmanager.NmDeviceTypeWifi{
+			fmt.Println(devices[i].GetPath())
+		}
+		
+	}
+
+}

--- a/Binary_Modules/GetAllWifiDevices/go.mod
+++ b/Binary_Modules/GetAllWifiDevices/go.mod
@@ -1,0 +1,8 @@
+module main
+
+go 1.19
+
+require (
+	github.com/Wifx/gonetworkmanager/v3 v3.0.0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
+)

--- a/Binary_Modules/GetAllWifiDevices/go.mod
+++ b/Binary_Modules/GetAllWifiDevices/go.mod
@@ -3,6 +3,11 @@ module main
 go 1.19
 
 require (
-	github.com/Wifx/gonetworkmanager/v3 v3.0.0 // indirect
+	github.com/Wifx/gonetworkmanager/v3 v3.0.0
+	github.com/alexflint/go-arg v1.5.1
+)
+
+require (
+	github.com/alexflint/go-scalar v1.2.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 )

--- a/Binary_Modules/GetAllWifiDevices/go.sum
+++ b/Binary_Modules/GetAllWifiDevices/go.sum
@@ -1,5 +1,12 @@
 github.com/Wifx/gonetworkmanager/v3 v3.0.0 h1:NBemr7aUazAKSQ6dEGzLcVJ00UT6U0b/iTgecOdUo1M=
 github.com/Wifx/gonetworkmanager/v3 v3.0.0/go.mod h1:JPAftRDTjp5o37GNOYytCzerFU8ZjudV/jC/g41kvHE=
+github.com/alexflint/go-arg v1.5.1 h1:nBuWUCpuRy0snAG+uIJ6N0UvYxpxA0/ghA/AaHxlT8Y=
+github.com/alexflint/go-arg v1.5.1/go.mod h1:A7vTJzvjoaSTypg4biM5uYNTkJ27SkNTArtYXnlqVO8=
+github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
+github.com/alexflint/go-scalar v1.2.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/Binary_Modules/GetAllWifiDevices/go.sum
+++ b/Binary_Modules/GetAllWifiDevices/go.sum
@@ -1,0 +1,5 @@
+github.com/Wifx/gonetworkmanager/v3 v3.0.0 h1:NBemr7aUazAKSQ6dEGzLcVJ00UT6U0b/iTgecOdUo1M=
+github.com/Wifx/gonetworkmanager/v3 v3.0.0/go.mod h1:JPAftRDTjp5o37GNOYytCzerFU8ZjudV/jC/g41kvHE=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/Binary_Modules/NetworkManager-GetAllAccessPoints/NetworkManager-GetAllAccessPoints.go
+++ b/Binary_Modules/NetworkManager-GetAllAccessPoints/NetworkManager-GetAllAccessPoints.go
@@ -22,7 +22,7 @@ var args struct {
 
 func if_err_log_and_die(err error){
 	if err != nil{
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }

--- a/Binary_Modules/NetworkManager-GetAllAccessPoints/NetworkManager-GetAllAccessPoints.go
+++ b/Binary_Modules/NetworkManager-GetAllAccessPoints/NetworkManager-GetAllAccessPoints.go
@@ -57,7 +57,7 @@ func get_all_wifi_devs() (result []gonetworkmanager.DeviceWireless , err error) 
 
 
 //path,ssid,is_password_protected
-func ouput_accesspoint_based_on_args(access_point gonetworkmanager.AccessPoint) error{
+func output_accesspoint_based_on_args(access_point gonetworkmanager.AccessPoint) error{
 	var print_string string = string(access_point.GetPath())
 	if args.Detailed {
 		ssid, err := access_point.GetPropertySSID()
@@ -108,7 +108,7 @@ func main() {
 	if_err_log_and_die(err)
 
 	for _,access_point := range access_points {
-		ouput_accesspoint_based_on_args(access_point)
+		output_accesspoint_based_on_args(access_point)
 	}
 
 	os.Exit(0)

--- a/Binary_Modules/NetworkManager-GetAllAccessPoints/NetworkManager-GetAllAccessPoints.go
+++ b/Binary_Modules/NetworkManager-GetAllAccessPoints/NetworkManager-GetAllAccessPoints.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"time"
+	"fmt"
+	"github.com/Wifx/gonetworkmanager/v3"
+	"os"
+)
+
+const SCAN_SLEEP_NSECS = 2
+
+func if_err_log_and_die(err error){
+	if err != nil{
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+}
+
+func get_all_wifi_devs() (result []gonetworkmanager.DeviceWireless , err error) {
+	var devices []gonetworkmanager.Device
+	devices, err = nm.GetPropertyAllDevices()
+	if err != nil {
+		return
+	}
+
+	var device_type gonetworkmanager.NmDeviceType
+	for _, device := range devices {
+		device_type, err = device.GetPropertyDeviceType()
+		if err != nil {
+			return
+		}	
+		if device_type != gonetworkmanager.NmDeviceTypeWifi {
+			continue
+		}
+
+		to_wifi, err:= gonetworkmanager.NewDeviceWireless(device.GetPath())
+		if err != nil {
+			continue
+		}
+		result = append(result, to_wifi)
+	}
+	
+	return 
+}
+
+var nm gonetworkmanager.NetworkManager
+func main() {
+
+	/* Create new instance of gonetworkmanager */
+	var err error
+	nm, err = gonetworkmanager.NewNetworkManager()
+	if_err_log_and_die(err)
+
+	wifi_devices, err := get_all_wifi_devs()
+	if_err_log_and_die(err)
+	if (len(wifi_devices) == 0){
+		return
+	}
+
+	wifi_devices[0].RequestScan()
+	time.Sleep(SCAN_SLEEP_NSECS)
+
+	var access_points []gonetworkmanager.AccessPoint
+	access_points, err = wifi_devices[0].GetAllAccessPoints()
+	if_err_log_and_die(err)
+
+	var device_state gonetworkmanager.NmDeviceState
+	device_state, err = wifi_devices[0].GetPropertyState()
+	if_err_log_and_die(err)
+
+	fmt.Println(device_state)
+	
+	for _,access_point := range access_points {
+		fmt.Println(access_point.GetPath())
+	}
+
+	
+
+	/* Show each device path and interface name */
+
+	os.Exit(0)
+}

--- a/Binary_Modules/NetworkManager-GetAllAccessPoints/go.mod
+++ b/Binary_Modules/NetworkManager-GetAllAccessPoints/go.mod
@@ -5,5 +5,7 @@ go 1.19
 require (
 	github.com/Wifx/gonetworkmanager v0.5.0 // indirect
 	github.com/Wifx/gonetworkmanager/v3 v3.0.0 // indirect
+	github.com/alexflint/go-arg v1.5.1 // indirect
+	github.com/alexflint/go-scalar v1.2.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 )

--- a/Binary_Modules/NetworkManager-GetAllAccessPoints/go.mod
+++ b/Binary_Modules/NetworkManager-GetAllAccessPoints/go.mod
@@ -1,0 +1,9 @@
+module main
+
+go 1.19
+
+require (
+	github.com/Wifx/gonetworkmanager v0.5.0 // indirect
+	github.com/Wifx/gonetworkmanager/v3 v3.0.0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
+)

--- a/Binary_Modules/NetworkManager-GetAllAccessPoints/go.sum
+++ b/Binary_Modules/NetworkManager-GetAllAccessPoints/go.sum
@@ -1,0 +1,9 @@
+github.com/Wifx/gonetworkmanager v0.5.0 h1:P209z0yj705bl5tmyHTlpXPSv3QzjPtIM4X0SyDAqWA=
+github.com/Wifx/gonetworkmanager v0.5.0/go.mod h1:EdhHf2O00IZXfMv9LC6CS6SgTwcMTg/ZSDhGvch0cs8=
+github.com/Wifx/gonetworkmanager/v3 v3.0.0 h1:NBemr7aUazAKSQ6dEGzLcVJ00UT6U0b/iTgecOdUo1M=
+github.com/Wifx/gonetworkmanager/v3 v3.0.0/go.mod h1:JPAftRDTjp5o37GNOYytCzerFU8ZjudV/jC/g41kvHE=
+github.com/godbus/dbus/v5 v5.0.2 h1:QtWdZQyXTEn7S0LXv9nVxPUiT37d1i7UntpRTiKM86E=
+github.com/godbus/dbus/v5 v5.0.2/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/Binary_Modules/NetworkManager-GetAllAccessPoints/go.sum
+++ b/Binary_Modules/NetworkManager-GetAllAccessPoints/go.sum
@@ -2,8 +2,15 @@ github.com/Wifx/gonetworkmanager v0.5.0 h1:P209z0yj705bl5tmyHTlpXPSv3QzjPtIM4X0S
 github.com/Wifx/gonetworkmanager v0.5.0/go.mod h1:EdhHf2O00IZXfMv9LC6CS6SgTwcMTg/ZSDhGvch0cs8=
 github.com/Wifx/gonetworkmanager/v3 v3.0.0 h1:NBemr7aUazAKSQ6dEGzLcVJ00UT6U0b/iTgecOdUo1M=
 github.com/Wifx/gonetworkmanager/v3 v3.0.0/go.mod h1:JPAftRDTjp5o37GNOYytCzerFU8ZjudV/jC/g41kvHE=
+github.com/alexflint/go-arg v1.5.1 h1:nBuWUCpuRy0snAG+uIJ6N0UvYxpxA0/ghA/AaHxlT8Y=
+github.com/alexflint/go-arg v1.5.1/go.mod h1:A7vTJzvjoaSTypg4biM5uYNTkJ27SkNTArtYXnlqVO8=
+github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
+github.com/alexflint/go-scalar v1.2.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/godbus/dbus/v5 v5.0.2 h1:QtWdZQyXTEn7S0LXv9nVxPUiT37d1i7UntpRTiKM86E=
 github.com/godbus/dbus/v5 v5.0.2/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/Binary_Modules/NetworkManager-GetAllAccessPoints/todo
+++ b/Binary_Modules/NetworkManager-GetAllAccessPoints/todo
@@ -1,0 +1,1 @@
+it would be nice to have the output sorted by signal strengh

--- a/Binary_Modules/NetworkManager-GetAllDevices/NetworkManager-GetAllDevices.go
+++ b/Binary_Modules/NetworkManager-GetAllDevices/NetworkManager-GetAllDevices.go
@@ -1,0 +1,23 @@
+package main
+
+import "fmt"
+import dbus "github.com/godbus/dbus/v5"
+	
+func main() {
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		fmt.Println("err")
+		fmt.Println(err)
+		return
+	}
+	obj := conn.Object("org.freedesktop.NetworkManager", "/org/freedesktop/NetworkManager")
+	call := obj.Call("org.freedesktop.NetworkManager.GetAllDevices", 0)
+	var result []string
+	if err := call.Store(&result); err != nil{
+		fmt.Println(err)
+		return
+	}
+	for i := 0 ; i < len(result); i++{
+		fmt.Println(result[i])
+	}
+}

--- a/Binary_Modules/NetworkManager-GetAllDevices/NetworkManager-GetAllDevices.go
+++ b/Binary_Modules/NetworkManager-GetAllDevices/NetworkManager-GetAllDevices.go
@@ -1,20 +1,22 @@
 package main
 
-import "fmt"
-import dbus "github.com/godbus/dbus/v5"
+import (
+	"fmt"
+	"os"
+	dbus "github.com/godbus/dbus/v5"
+)
 	
 func main() {
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
-		fmt.Println("err")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		return
 	}
 	obj := conn.Object("org.freedesktop.NetworkManager", "/org/freedesktop/NetworkManager")
 	call := obj.Call("org.freedesktop.NetworkManager.GetAllDevices", 0)
 	var result []string
 	if err := call.Store(&result); err != nil{
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		return
 	}
 	for i := 0 ; i < len(result); i++{

--- a/Binary_Modules/NetworkManager-GetAllDevices/go.mod
+++ b/Binary_Modules/NetworkManager-GetAllDevices/go.mod
@@ -1,0 +1,5 @@
+module main
+
+go 1.19
+
+require github.com/godbus/dbus/v5 v5.1.0 // indirect

--- a/Binary_Modules/NetworkManager-GetAllDevices/go.sum
+++ b/Binary_Modules/NetworkManager-GetAllDevices/go.sum
@@ -1,0 +1,2 @@
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/Binary_Modules/README.md
+++ b/Binary_Modules/README.md
@@ -1,0 +1,1 @@
+This directory contains binary modules that enable scripts to perform complex tasks.

--- a/Binary_Modules/README.md
+++ b/Binary_Modules/README.md
@@ -1,1 +1,7 @@
-This directory contains binary modules that enable scripts to perform complex tasks.
+# Purpose Of This Directory
+This directory contains binary modules that enable scripts to perform complex tasks.  
+# Why File Names in Binary Modules Are In Pascal Case?
+The reason for this is binary modules initial offered capabilities (if not all) is to facilitate using various dbus APIs on linux. Methods exposed via dbus are typically (if not always) in pascal case, so we kept it for better readability.
+# Modules With Prefix 'NetworkManager-*'
+These modules directly map to a method offered by NetworkManager.
+

--- a/Binary_Modules/TryToConnectToAccessPoint/TryToConnectToAccessPoint.go
+++ b/Binary_Modules/TryToConnectToAccessPoint/TryToConnectToAccessPoint.go
@@ -13,7 +13,6 @@ import (
 )
 
 var args struct {
-	Detailed bool
 	No_sleep bool `default:false`
 	AccessPoint_Path string `arg:"required"`
 	Device_Path string `arg:"required"`

--- a/Binary_Modules/TryToConnectToAccessPoint/TryToConnectToAccessPoint.go
+++ b/Binary_Modules/TryToConnectToAccessPoint/TryToConnectToAccessPoint.go
@@ -25,7 +25,7 @@ const (
 
 func if_err_log_and_die(err error){
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/Binary_Modules/TryToConnectToAccessPoint/TryToConnectToAccessPoint.go
+++ b/Binary_Modules/TryToConnectToAccessPoint/TryToConnectToAccessPoint.go
@@ -31,13 +31,15 @@ func if_err_log_and_die(err error){
 }
 
 func is_activeconnection_present(connection gonetworkmanager.ActiveConnection) (bool){
-	_, err := connection.GetPropertyID()
+	conn, err := connection.GetPropertyConnection()
 
 	if err != nil {
 		return false
-	} else {
-		return true
 	}
+	if conn == nil {
+		return false
+	}
+	return true
 }
 
 func get_all_wifi_devs(nm gonetworkmanager.NetworkManager) (result []gonetworkmanager.DeviceWireless , err error) {
@@ -146,6 +148,7 @@ func main (){
 	if connection_success == false {
 		//TODO delete the setting generated in NetworkManager
 		//_ , err:= number_generated_for_connection_by_nm(conn)
+		exit_code = 1
 		if_err_log_and_die(err)
 	}
 

--- a/Binary_Modules/TryToConnectToAccessPoint/TryToConnectToAccessPoint.go
+++ b/Binary_Modules/TryToConnectToAccessPoint/TryToConnectToAccessPoint.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Wifx/gonetworkmanager/v3"
+	"github.com/alexflint/go-arg"
+	"github.com/godbus/dbus/v5"
+)
+
+var args struct {
+	Detailed bool
+	No_sleep bool `default:false`
+	AccessPoint_Path string `arg:"required"`
+	Device_Path string `arg:"required"`
+}
+
+const (
+	SCAN_SLEEP_NSECS = 3
+)
+
+func if_err_log_and_die(err error){
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+}
+
+func is_activeconnection_present(connection gonetworkmanager.ActiveConnection) (bool){
+	_, err := connection.GetPropertyID()
+
+	if err != nil {
+		return false
+	} else {
+		return true
+	}
+}
+
+func get_all_wifi_devs(nm gonetworkmanager.NetworkManager) (result []gonetworkmanager.DeviceWireless , err error) {
+	var devices []gonetworkmanager.Device
+	devices, err = nm.GetPropertyAllDevices()
+	if err != nil {
+		return
+	}
+
+	var device_type gonetworkmanager.NmDeviceType
+	for _, device := range devices {
+		device_type, err = device.GetPropertyDeviceType()
+		if err != nil {
+			return
+		}	
+		if device_type != gonetworkmanager.NmDeviceTypeWifi {
+			continue
+		}
+
+		to_wifi, err:= gonetworkmanager.NewDeviceWireless(device.GetPath())
+		if err != nil {
+			continue
+		}
+		result = append(result, to_wifi)
+	}
+	
+	return 
+}
+
+func get_all_access_points(nm gonetworkmanager.NetworkManager)(result []gonetworkmanager.AccessPoint, err error){
+
+	wifi_devices, err := get_all_wifi_devs(nm)
+	if err != nil {
+		return 
+	}
+	if (len(wifi_devices) == 0){
+		return
+	}
+
+	for _, wifi_dev := range wifi_devices{
+		wifi_dev.RequestScan()
+	}
+	if args.No_sleep == false{
+		time.Sleep(time.Second * SCAN_SLEEP_NSECS)
+	}
+
+	var access_points []gonetworkmanager.AccessPoint
+	for _, wifi_dev := range wifi_devices {
+		access_points, err = wifi_dev.GetAllAccessPoints()
+		if err != nil{
+			return 
+		}
+		result = append(result, access_points...)
+
+	}
+
+	return result, nil
+}
+
+func number_generated_for_connection_by_nm(connection gonetworkmanager.ActiveConnection) (int64, error) {
+
+	splited := strings.Split(string(connection.GetPath()), "/")
+	str := splited[ len(splited) - 1 ]
+	return strconv.ParseInt(str, 10, 64) 
+
+}
+
+func main (){	
+	exit_code := 0
+
+	arg.MustParse(&args)
+	nm, err := gonetworkmanager.NewNetworkManager()
+	if_err_log_and_die(err)
+
+	ap, err := gonetworkmanager.NewAccessPoint(dbus.ObjectPath(args.AccessPoint_Path))
+	if_err_log_and_die(err)
+
+	wifi_dev, err := gonetworkmanager.NewDeviceWireless(dbus.ObjectPath(args.Device_Path))
+	if_err_log_and_die(err)
+
+	connection := make(map[string]map[string]interface{})
+
+	ssid, err := ap.GetPropertySSID()
+	if_err_log_and_die(err)
+
+	connection["802-11-wireless"] = make(map[string]interface{})
+	connection["802-11-wireless"]["ssid"] = ssid 
+
+	connection["connection"] = make(map[string]interface{})
+	connection["connection"]["id"] = ssid
+	connection["connection"]["type"] = "802-11-wireless"
+
+	ifname, err := wifi_dev.GetPropertyInterface()
+	connection["connection"]["interface-name"] = ifname
+
+	conn, err := nm.AddAndActivateWirelessConnection(connection, wifi_dev, ap)
+	if_err_log_and_die(err)
+
+	time.Sleep(5 * time.Second)
+	if_err_log_and_die(err)
+
+	
+	connection_success := is_activeconnection_present(conn)
+	if_err_log_and_die(err)
+
+	if connection_success == false {
+		//TODO delete the setting generated in NetworkManager
+		//_ , err:= number_generated_for_connection_by_nm(conn)
+		if_err_log_and_die(err)
+	}
+
+
+	if_err_log_and_die(err)
+	os.Exit(exit_code)
+
+}

--- a/Binary_Modules/TryToConnectToAccessPoint/go.mod
+++ b/Binary_Modules/TryToConnectToAccessPoint/go.mod
@@ -1,0 +1,13 @@
+module main
+
+go 1.19
+
+require (
+	github.com/Wifx/gonetworkmanager/v3 v3.0.0
+	github.com/alexflint/go-arg v1.5.1
+)
+
+require (
+	github.com/alexflint/go-scalar v1.2.0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
+)

--- a/Binary_Modules/TryToConnectToAccessPoint/go.sum
+++ b/Binary_Modules/TryToConnectToAccessPoint/go.sum
@@ -1,0 +1,12 @@
+github.com/Wifx/gonetworkmanager/v3 v3.0.0 h1:NBemr7aUazAKSQ6dEGzLcVJ00UT6U0b/iTgecOdUo1M=
+github.com/Wifx/gonetworkmanager/v3 v3.0.0/go.mod h1:JPAftRDTjp5o37GNOYytCzerFU8ZjudV/jC/g41kvHE=
+github.com/alexflint/go-arg v1.5.1 h1:nBuWUCpuRy0snAG+uIJ6N0UvYxpxA0/ghA/AaHxlT8Y=
+github.com/alexflint/go-arg v1.5.1/go.mod h1:A7vTJzvjoaSTypg4biM5uYNTkJ27SkNTArtYXnlqVO8=
+github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
+github.com/alexflint/go-scalar v1.2.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/Binary_Modules/build.sh
+++ b/Binary_Modules/build.sh
@@ -1,0 +1,19 @@
+mkdir bin 2>/dev/null
+exception_dirs="bin" #insert '|' between exceptions to make grep -E work
+for dir in $(ls -F | grep '/' | grep -v -E "$exception_dirs"); do
+	(
+	cd $dir
+
+	expected_bin_name=$(pwd | sed -e 's/.*\///')
+
+	go build ${expected_bin_name}.go
+	if [ "$?" != "0" ];then
+		exit 1
+	fi
+
+	mv $expected_bin_name ../bin/
+	)
+
+done
+
+

--- a/Libraries/depcheck/depcheck.sh
+++ b/Libraries/depcheck/depcheck.sh
@@ -39,17 +39,21 @@ function depcheck_cmd(){
 				return 1
 		fi
 
+		OLD_PATH="$PATH"
+		#this is done because in some linux distributions /sbin and /usr/sbin are not in PATH, like debian
+		PATH=$PATH:/sbin:/usr/sbin
 		while read -r line;do
 				cmd="$(_dep_attr_extract "$line" "$DEP_CMD_POS" "$dep_attr_delim")"
 				log $LOG_LVL_DEBUG "[$0]: checking cmd $cmd"
 
-				if ! type $cmd &>/dev/null;then
+				if ! type "$cmd" &>/dev/null;then
 						log "$LOG_LVL_ERROR" "[$0]: missing dependancy : $(_dep_attr_extract "$line" "$DEP_NAME_POS" "$dep_attr_delim")"
 						IFS="$OLD_IFS"
 						return 1
 				fi
 
 		done <<<"$deps"
+		PATH="$OLD_PATH"
 
 		return 0
 }
@@ -67,17 +71,21 @@ function depcheck_cmd_fromstr(){
 		deps="$1"
 		dep_attr_delim="${2:-$DEP_ATTR_DELIM}"
 
+		OLD_PATH="$PATH"
+		#this is done because in some linux distributions /sbin and /usr/sbin are not in PATH, like debian
+		PATH=$PATH:/sbin:/usr/sbin
 		while read -r line;do
 				cmd="$(_dep_attr_extract "$line" "$DEP_CMD_POS" "$dep_attr_delim")"
 				log $LOG_LVL_DEBUG "[$0]: checking cmd $cmd"
 
-				if ! type $cmd &>/dev/null;then
+				if ! type "$cmd" &>/dev/null;then
 						log "$LOG_LVL_ERROR" "[$0]: missing dependancy : $(_dep_attr_extract "$line" "$DEP_NAME_POS" "$dep_attr_delim")"
 						IFS="$OLD_IFS"
 						return 1
 				fi
 
 		done <<<"$deps"
+		PATH="$OLD_PATH"
 
 		return 0
 }

--- a/Scripts/Internet Problem Fixer/interface_ignore.txt
+++ b/Scripts/Internet Problem Fixer/interface_ignore.txt
@@ -1,4 +1,0 @@
-lo
-docker0
-tun0
-neko-tun

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -42,7 +42,7 @@ Options:\n\
 \t-v\t\t\t\tverbose\n\
 \t-d\t\t\t\tdebug: redirect the used commands to stdout\n\
 \t-n\t\t\t\tno fix: don't try to fix ( eliminate the requirement for the script to be root )\n\
-\t-i INTERFACE_NAMES\t\tinclude interface: troubleshoot the provided interfaces only if used. -x will be ignored\n\
+\t-i INTERFACE_NAMES\t\tinclude interface: troubleshoot the provided interfaces only. if used, -x will be ignored\n\
 \t-I \t\t\t\tinteractive mode: if not set user won't be asked for input and will not be prompted for anything\n\
 \t-x INTERFACE_NAMES\t\texclude interface: ignore the provided interfaces\n\
 \t-p PING_OPTION=VALUE,..\t\tpass arbitrary switches to pings used in the script, seperated by ',' and wrappen in double qoutes '\"'\n\

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -755,6 +755,7 @@ function try_to_fix_interface_wireless {
 		fi
 		if check_internet_connectivity "$interface_name" ;then
 			errno=0
+			# we don't care about other accesspoints if we reach the internet via the currrent one
 			break
 		fi
 	done
@@ -770,6 +771,8 @@ function try_to_fix_interface {
 
 	if is_wifi "$interface_name";then
 		try_to_fix_interface_wireless "$interface_name"
+		# try_to_fix_interface_wireless will call check_internet_connectivity, because it needs to know if the 
+		# accesspoint it is currently connected to provides internet or not, so it can return 0 if internet connectivity is achived
 		return $?
 	else
 		try_to_fix_interface_wired "$interface_name"

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -511,8 +511,6 @@ function handle_args {
 							TIMEOUT="$OPTARG";;
 					c) 		
 							PING_COUNT="$OPTARG";;
-					f)
-							EXCLUDED_INTERFACES_FILE="$OPTARG";;
 					?)    
 							echo -e $HELP
 							exit 1;;

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -745,7 +745,7 @@ function try_to_fix_interface_wireless {
 		fi
 		if check_internet_connectivity "$interface_name" ;then
 			errcode=0
-			break
+			continue
 		fi
 	done
 	IFS="$OLD_IFS"

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -118,7 +118,7 @@ VERBOSE_LOG_LVL=50
 DEBUG_LOG_LVL=100
 
 
-#renamed to __CURRENT_LOG_LVL to resolve conflict with abs.lib.logging
+#renamed to _CURRENT_LOG_LVL to resolve conflict with abs.lib.logging
 _CURRENT_LOG_LVL=$DEFAULT_LOG_LVL
 
 #COMMANDNAME_SWITCHES are used along each COMMANDNAME, this is portability (to test if different switches work on current machine)

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -666,6 +666,15 @@ function init_accesspoints {
 	ACCESSPOINTS="$(abs.bin.NetworkManager-GetAllAccessPoints --detailed 2>/dev/null)"
 	log "${BLUE}[*] found accesspoints:" $VERBOSE_LOG_LVL
 	log "${BLUE}[*] $ACCESSPOINTS:" $VERBOSE_LOG_LVL
+
+	found_ap_ssids=""
+
+	IFS="$OLD_IFS"
+	IFS="$ACCESSPOINTS_DELIM"
+	for accesspoint in $ACCESSPOINTS;do
+		found_ap_ssids="${found_ap_ssids} $(get_accesspoint_ssid "$accesspoint")"
+	done
+	log "${BLUE}[*] found wifi accesspoints: $found_ap_ssids" $CURRENT_LOG_LVL
 }
 
 function get_wifi_dev_interface_name {

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -696,18 +696,18 @@ function get_wifi_dev_from_interface_name {
 function is_wifi {
 	interface_name="$1"
 
-	errcode=1
+	errno=1
 
 	OLD_IFS="$IFS"
 	IFS="$WIFI_DEVS_DELIM"
 	for wifi_dev in $WIFI_DEVS;do
 		if [ "$(get_wifi_dev_interface_name "$wifi_dev")" = "$interface_name" ];then
-			errcode=0
+			errno=0
 		fi
 	done
 	IFS="$OLD_IFS"
 
-	return $errcode 
+	return $errno 
 }
 
 function get_accesspoint_path {
@@ -725,7 +725,7 @@ function get_accesspoint_ssid {
 function try_to_fix_interface_wireless {
 	interface_name="$1"
 	
-	errcode=1
+	errno=1
 
 	OLD_IFS="$IFS"
 	IFS="$ACCESSPOINTS_DELIM"
@@ -736,8 +736,8 @@ function try_to_fix_interface_wireless {
 			--accesspoint_path $(get_accesspoint_path "$accesspoint" 2>/dev/null)\
 			--device_path $(get_wifi_dev_path "$device" 2>/dev/null)\
 			2>/dev/null
-		err=$?
-		if [[ $err -ne 0 ]];then
+		errno=$?
+		if [[ $errno -ne 0 ]];then
 			continue
 		fi
 		log "${BLUE}[*] connected to wireless network $(get_accesspoint_ssid $accesspoint)" $CURRENT_LOG_LVL
@@ -745,13 +745,13 @@ function try_to_fix_interface_wireless {
 			dhcp_renew "$interface_name"
 		fi
 		if check_internet_connectivity "$interface_name" ;then
-			errcode=0
+			errno=0
 			break
 		fi
 	done
 	IFS="$OLD_IFS"
 
-	return $errcode
+	return $errno
 }
 #end of wifi support
 

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -799,7 +799,7 @@ function main {
 		fi
 		if ! depcheck_cmd_fromstr "$WIFI_DEPENDANCIES_CMD"; then
 			DENY_IS_WIFI=1
-			_log "${YELLOW}[-] wifi support dependencies are not met, will treat wifi interfaces like wired interfaces${NC}" $_CURRENT_LOG_LVL
+			_log "${YELLOW}[!] wifi support dependencies are not met, will treat wifi interfaces like wired interfaces${NC}" $_CURRENT_LOG_LVL
 		fi
 		
 		handle_args $@

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -443,6 +443,9 @@ function set_reliable_dns {
 }
 
 function try_to_fix_interface {
+		#TODO: if interface is wifi, try to connect nearest accesspoint and check if 
+		#can connect to internet, if not repeat for the next nearest accesspoint 
+
 		interface_name="$1"
 		if [[ $INTERFACE_STATE = 0 ]];then
 				log "${BLUE}[*] restarting interface $interface_name${NC}" $VERBOSE_LOG_LVL

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -24,7 +24,7 @@ Options:\n\
 \t-v\t\t\t\tverbose\n\
 \t-d\t\t\t\tdebug: redirect the used commands to stdout\n\
 \t-n\t\t\t\tno fix: don't try to fix ( eliminate the requirement for the script to be root )\n\
-\t-i INTERFACE_NAMES\t\tinclude interface: troubleshoot the provided interfaces only if used -x will be ignored\n\
+\t-i INTERFACE_NAMES\t\tinclude interface: troubleshoot the provided interfaces only if used. -x will be ignored\n\
 \t-x INTERFACE_NAMES\t\texclude interface: ignore the provided interfaces\n\
 \t-p PING_OPTION=VALUE,..\t\tpass arbitrary switches to pings used in the script, seperated by ',' and wrappen in double qoutes '\"'\n\
 \t\t*reserved switches: (-A, -I, -c, -W) there are other switches to set arbitrary value for -c, -W\n\

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -737,7 +737,7 @@ function try_to_fix_interface_wireless {
 			--device_path $(get_wifi_dev_path "$device")
 		err=$?
 		if [[ $err -ne 0 ]];then
-			return
+			continue
 		fi
 		log "${BLUE}[*] connected to wireless network $(get_accesspoint_ssid $accesspoint)" $CURRENT_LOG_LVL
 		if ! check_lan_connectivity "$interface_name" ;then
@@ -745,7 +745,7 @@ function try_to_fix_interface_wireless {
 		fi
 		if check_internet_connectivity "$interface_name" ;then
 			errcode=0
-			continue
+			break
 		fi
 	done
 	IFS="$OLD_IFS"

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -5,14 +5,14 @@ source abs.lib.depcheck
 #used to push and pop IFS
 OLD_IFS=$IFS
 
-ESSENTIAL_DEPENDANCIES_CMD="\
+readonly ESSENTIAL_DEPENDANCIES_CMD="\
 inetutils-ping,ping
 iproute2,ip
 dnsutils,nslookup
 isc-dhcp-client,dhclient\
 "
 
-WIFI_DEPENDANCIES_CMD="\
+readonly WIFI_DEPENDANCIES_CMD="\
 network-manager,NetworkManager
 awesome bash scripts binary modules,abs.bin.TryToConnectToAccessPoint
 awesome bash scripts binary modules,abs.bin.NetworkManager-GetAllAccessPoints
@@ -20,11 +20,11 @@ awesome bash scripts binary modules,abs.bin.GetAllWifiDevices\
 "
 
 #terminal colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[0;33m'
+readonly BLUE='\033[0;34m'
+readonly NC='\033[0m'
 
 #runtime flags/configs
 REDIRECT_DEST="/dev/null"
@@ -36,7 +36,7 @@ TRY_TO_FIX=1
 INTERACTIVE_MODE=0
 
 
-HELP="\
+readonly HELP="\
 Internet problem fixer\\n\
 Options:\n\
 \t-v\t\t\t\tverbose\n\
@@ -59,16 +59,16 @@ Usage Examples:\n\
 
 
 #google dns primary and secondary, example.com, google.com
-INTERNET_IPV4S=("8.8.8.8" "8.8.4.4" "93.184.215.14" "142.250.184.206")
-INTERNET_DOMAINS=("google.com" "example.com" "github.com")
+readonly INTERNET_IPV4S=("8.8.8.8" "8.8.4.4" "93.184.215.14" "142.250.184.206")
+readonly INTERNET_DOMAINS=("google.com" "example.com" "github.com")
 #shecan.ir, shecan primary and secondary dns, shatel.ir
-INTRANET_IPV4S=("88.135.36.244" "178.22.122.100" "178.22.122.100" "85.15.17.13")
-INTRANET_DOMAINS=("shecan.ir" "shatel.ir")
+readonly INTRANET_IPV4S=("88.135.36.244" "178.22.122.100" "178.22.122.100" "85.15.17.13")
+readonly INTRANET_DOMAINS=("shecan.ir" "shatel.ir")
 
 
 #regex strings
-IPV4_REGEX="([[:digit:]]{1,3}\.){3}[[:digit:]]{1,3}"
-IPV4_NETMASK_REGEX="/[[:digit:]]{1,2}"
+readonly IPV4_REGEX="([[:digit:]]{1,3}\.){3}[[:digit:]]{1,3}"
+readonly IPV4_NETMASK_REGEX="/[[:digit:]]{1,2}"
 
 #state flags (-1 not checked 0 doesnt work 1 works )
 #is for the $CURRENT_INTERFACE
@@ -94,30 +94,30 @@ LAST_DNS_STATE=-1
 # 	-all get functions provide the list of asked interfaces with the delimiter being $INTERFACE_LIST_DELIMITER
 # 	-all switches that accept a list of interfaces as argument use the $INTERFACE_LIST_DELIMITER
 # 	-all loops in interface lists should set IFS to $INTERFACE_LIST_DELIMITER
-INTERFACE_LIST_DELIMITER=","
+readonly INTERFACE_LIST_DELIMITER=","
 #interfaces that are expected to be able to reach internet
 TARGET_INTERFACES=""
 #script runs for the first target and after the fix can run for the other
 CURRENT_INTERFACE=""
 #-x --exclude input
-DEFAULT_EXCLUDED_INTERFACES="\
+readonly DEFAULT_EXCLUDED_INTERFACES="\
 lo${INTERFACE_LIST_DELIMITER}docker0${INTERFACE_LIST_DELIMITER}neko-tun${INTERFACE_LIST_DELIMITER}tun0\
 "
 EXCLUDED_INTERFACES=""
 #-i --interface input
 INCLUDED_INTERFACES=""
 
-RELIABLE_DNS_SERVER1="8.8.8.8"
-RELIABLE_DNS_SERVER2="8.8.4.4"
+readonly RELIABLE_DNS_SERVER1="8.8.8.8"
+readonly RELIABLE_DNS_SERVER2="8.8.4.4"
 
 #used to seperate the output of some function from another
-LINE_DELIMITER="--------------------------"
+readonly LINE_DELIMITER="--------------------------"
 
 #_log levels
 #10-40 and 60-90 are reserved for the future use
-DEFAULT_LOG_LVL=0
-VERBOSE_LOG_LVL=50
-DEBUG_LOG_LVL=100
+readonly DEFAULT_LOG_LVL=0
+readonly VERBOSE_LOG_LVL=50
+readonly DEBUG_LOG_LVL=100
 
 
 #renamed to _CURRENT_LOG_LVL to resolve conflict with abs.lib.logging
@@ -130,9 +130,9 @@ _CURRENT_LOG_LVL=$DEFAULT_LOG_LVL
 PING_SWITCHES=""
 
 #assumed global variables typically to test things when an actual valid one is not availbale
-ASSUMED_RELIABLE_IP="127.0.0.1"
+readonly ASSUMED_RELIABLE_IP="127.0.0.1"
 #WARNING! ASSUMED_RELIABLE_IP must be reachable via ASSUMED_AVAILABLE_INTERFACE_NAME
-ASSUMED_AVAILABLE_INTERFACE_NAME="lo"
+readonly ASSUMED_AVAILABLE_INTERFACE_NAME="lo"
 
 #renamed to _log to resolve conflict with abs.lib.logging
 function _log {
@@ -743,14 +743,14 @@ function init_ping_switches {
 
 #start of wifi support 
 
-WIFI_DEV_PROPERTY_DELIM=","
-WIFI_DEVS_DELIM=$'\n'
+readonly WIFI_DEV_PROPERTY_DELIM=","
+readonly WIFI_DEVS_DELIM=$'\n'
 #NetworkManager device path,interface name
 WIFI_DEVS=""
 
 
-ACCESSPOINT_PROPERTY_DELIM=","
-ACCESSPOINTS_DELIM=$'\n'
+readonly ACCESSPOINT_PROPERTY_DELIM=","
+readonly ACCESSPOINTS_DELIM=$'\n'
 #NetworkManager device path,SSID,wpaflags
 ACCESSPOINTS=""
 

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -917,8 +917,11 @@ function main {
 		if ip addr | grep tun >$REDIRECT_DEST;then
 				_log "${YELLOW}[!] please turn off your vpn${NC}" $DEFAULT_LOG_LVL
 		fi
-		init_wifi_devs
-		init_accesspoints
+
+		if [[ $DENY_IS_WIFI -eq 0 ]];then
+			init_wifi_devs
+			init_accesspoints
+		fi
 		init_determine_target_interfaces
 		init_ping_switches
 

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -656,14 +656,14 @@ ACCESSPOINTS_DELIM=$'\n'
 ACCESSPOINTS=""
 
 function init_wifi_devs {
-	WIFI_DEVS="$(abs.bin.GetAllWifiDevices --detailed)"
+	WIFI_DEVS="$(abs.bin.GetAllWifiDevices --detailed 2>/dev/null)"
 	log "${BLUE}[*] found wifi devices:" $VERBOSE_LOG_LVL
 	log "${BLUE}[*] $WIFI_DEVS" $VERBOSE_LOG_LVL
 }
 
 function init_accesspoints {
 	log "${BLUE}[*] scanning for accesspoints" $CURRENT_LOG_LVL
-	ACCESSPOINTS="$(abs.bin.NetworkManager-GetAllAccessPoints --detailed)"
+	ACCESSPOINTS="$(abs.bin.NetworkManager-GetAllAccessPoints --detailed 2>/dev/null)"
 	log "${BLUE}[*] found accesspoints:" $VERBOSE_LOG_LVL
 	log "${BLUE}[*] $ACCESSPOINTS:" $VERBOSE_LOG_LVL
 }
@@ -733,8 +733,9 @@ function try_to_fix_interface_wireless {
 	for accesspoint in $ACCESSPOINTS;do
 		device="$(get_wifi_dev_from_interface_name "$interface_name")"
 		abs.bin.TryToConnectToAccessPoint \
-			--accesspoint_path $(get_accesspoint_path "$accesspoint")\
-			--device_path $(get_wifi_dev_path "$device")
+			--accesspoint_path $(get_accesspoint_path "$accesspoint" 2>/dev/null)\
+			--device_path $(get_wifi_dev_path "$device" 2>/dev/null)\
+			2>/dev/null
 		err=$?
 		if [[ $err -ne 0 ]];then
 			continue

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -620,7 +620,7 @@ function remove_list_from_list {
 
 function init_determine_target_interfaces {
 
-		if ! [ -z $INCLUDED_INTERFACES ];then
+		if [ -n $INCLUDED_INTERFACES ];then
 				TARGET_INTERFACES="$INCLUDED_INTERFACES"
 				_log "targeted interfaces: $TARGET_INTERFACES" $DEBUG_LOG_LVL
 				return

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -13,7 +13,6 @@ dnsutils,nslookup
 isc-dhcp-client,dhclient\
 "
 
-
 #terminal colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -112,7 +111,7 @@ VERBOSE_LOG_LVL=50
 DEBUG_LOG_LVL=100
 
 
-#renamed to __CURRENT_LOG_LVL to resolve conflict with abs.bin.logging
+#renamed to __CURRENT_LOG_LVL to resolve conflict with abs.lib.logging
 _CURRENT_LOG_LVL=$DEFAULT_LOG_LVL
 
 #COMMANDNAME_SWITCHES are used along each COMMANDNAME, this is portability (to test if different switches work on current machine)
@@ -126,7 +125,7 @@ ASSUMED_RELIABLE_IP="127.0.0.1"
 #WARNING! ASSUMED_RELIABLE_IP must be reachable via ASSUMED_AVAILABLE_INTERFACE_NAME
 ASSUMED_AVAILABLE_INTERFACE_NAME="lo"
 
-#renamed to _log to resolve conflict with abs.bin.logging
+#renamed to _log to resolve conflict with abs.lib.logging
 function _log {
  	string="$1"
 	_log_level="$2"

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -809,8 +809,9 @@ function main {
 				exec sudo bash $0 $@
 		fi
 
+		#if there's a interface that has 'tun' in it, it's probably a tunnel interface, we advice the user to turn off the vpn
 		if ip addr | grep tun >$REDIRECT_DEST;then
-				_log "${YELLOW}please turn off your vpn${NC}" $DEFAULT_LOG_LVL
+				_log "${YELLOW}[!] please turn off your vpn${NC}" $DEFAULT_LOG_LVL
 		fi
 		init_determine_target_interfaces
 		init_ping_switches

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -33,6 +33,8 @@ TIMEOUT="1"
 INTERFACE_CHANGE_STATE_SLEEP="1"
 DHCP_COMPLETION_SLEEP="10"
 TRY_TO_FIX=1
+INTERACTIVE_MODE=0
+
 
 HELP="\
 Internet problem fixer\\n\
@@ -131,9 +133,6 @@ PING_SWITCHES=""
 ASSUMED_RELIABLE_IP="127.0.0.1"
 #WARNING! ASSUMED_RELIABLE_IP must be reachable via ASSUMED_AVAILABLE_INTERFACE_NAME
 ASSUMED_AVAILABLE_INTERFACE_NAME="lo"
-
-#if is zero-length will not prompt for any input, will be overwritten by handle_args()
-INTERACTIVE_MODE=""
 
 #renamed to _log to resolve conflict with abs.lib.logging
 function _log {
@@ -324,7 +323,7 @@ function check_daemon {
 
 	if ! systemctl is-active "$daemon" &>$REDIRECT_DEST;then
 			_log "${YELLOW}[!] $daemon is not running${NC}" "$_CURRENT_LOG_LVL" 
-		if [ -n "$do_prompt" ];then
+		if [[ $do_prompt -ne 0 ]];then
 			_log "start and enable?[y/N]" "$_CURRENT_LOG_LVL"
 			read -r confirm
 		fi
@@ -335,7 +334,7 @@ function check_daemon {
 			start_success=$?
 		fi
 
-		if [ -n "$do_prompt" ] && [[ $start_success -eq 0 ]];then
+		if [[ $do_prompt -ne 0 ]] && [[ $start_success -eq 0 ]];then
 			_log "${GREEN}[+] $daemon successfully started${NC}" "$_CURRENT_LOG_LVL"
 		else
 			_log "${RED}[-] failed to start $daemon ${NC}" "$_CURRENT_LOG_LVL"
@@ -348,7 +347,7 @@ function check_daemon {
 
 # check_daemon_* functions check if daemons needed for a certain feature are running or not
 # Parameters: 
-# 	do_prompt: if non-zero length then prompt the user to start and enable the daemon if not running
+# 	do_prompt: if set to 1 then prompt the user to start and enable the daemon if not running
 # Returns:
 # 	non-zero on error
 

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -857,6 +857,10 @@ function main {
 						fi
 
 				done		
+
+				if [[ $INTERNET_STATE -eq 1 ]];then
+					exit 0
+				fi
 		done
 		IFS=$OLD_IFS
 }

--- a/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
+++ b/Scripts/Internet Problem Fixer/internet-problem-fixer.sh
@@ -519,11 +519,13 @@ function handle_args {
 					esac
 		done
 
+}
+
+function assign_default_value_args {
 		if [ -z "$EXCLUDED_INTERFACES" ];then
 			_log "${YELLOW}[!] the following interfaces are ignored by default, use -x to change: $DEFAULT_EXCLUDED_INTERFACES${NC}" $CURRENT_LOG_LVL
 			EXCLUDED_INTERFACES="$DEFAULT_EXCLUDED_INTERFACES"
 		fi
-
 }
 
 function is_current_interface_ok {
@@ -809,12 +811,13 @@ function main {
 			_log "${YELLOW}[!] wifi support dependencies are not met, will treat wifi interfaces like wired interfaces${NC}" $_CURRENT_LOG_LVL
 		fi
 		
+		#will assign default value of args when we ensured the script won't be called recursivly again, so each warning is shown once
+		#so we call assign_default_value_args after the potential exec sudo bash $0 $@
 		handle_args $@
-
-		
 		if [[ $TRY_TO_FIX = 1 ]] && [[ $EUID != 0 ]];then
-				exec sudo bash $0 $@
+				exec sudo bash "$0" $@
 		fi
+		assign_default_value_args
 
 		#if there's a interface that has 'tun' in it, it's probably a tunnel interface, we advice the user to turn off the vpn
 		if ip addr | grep tun >$REDIRECT_DEST;then

--- a/Scripts/Internet Problem Fixer/known-issues
+++ b/Scripts/Internet Problem Fixer/known-issues
@@ -1,0 +1,1 @@
+warnings about dependancies are shown two times, once before re executing self as root and once after

--- a/Scripts/Internet Problem Fixer/known-issues
+++ b/Scripts/Internet Problem Fixer/known-issues
@@ -1,1 +1,0 @@
-warnings about dependancies are shown two times, once before re executing self as root and once after

--- a/Scripts/Internet Problem Fixer/notes.md
+++ b/Scripts/Internet Problem Fixer/notes.md
@@ -1,4 +1,5 @@
 # current priorities    
+- fix wifi device being unavailable for network manager (iwd being manaually started by the user)
 - check if both wpa_supplicant and iwd is running, then remove one of them
 - check if a wireless support daemon is running, if not, try to start or install
 - dynamic sleep for dhclient and monitor if route table is updated    

--- a/Scripts/Internet Problem Fixer/notes.md
+++ b/Scripts/Internet Problem Fixer/notes.md
@@ -1,4 +1,6 @@
 # current priorities    
+- check if both wpa_supplicant and iwd is running, then remove one of them
+- check if a wireless support daemon is running, if not, try to start or install
 - dynamic sleep for dhclient and monitor if route table is updated    
 - VPN detection and asking the user to turn it off    
 - detect and igore VPN interfaces by default  

--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,13 @@ GLOBAL_PREFIX="abs"
 DESTINATION_DIR="/usr/bin"
 #list of tuples of (source_directory,prefix)
 INSTALL_SOURCES_DELIM=","
+
+#source_dir, prefix of installed file name, type of file (none for elf files)
 INSTALL_SOURCES="\
-Scripts${INSTALL_SOURCES_DELIM}
-Libraries${INSTALL_SOURCES_DELIM}lib"
+Scripts${INSTALL_SOURCES_DELIM}${INSTALL_SOURCES_DELIM}.sh
+Libraries${INSTALL_SOURCES_DELIM}lib${INSTALL_SOURCES_DELIM}.sh
+Binary_Modules/bin/${INSTALL_SOURCES_DELIM}bin${INSTALL_SOURCES_DELIM}
+"
 
 #maybe this should be a library too!
 #abs_install(source_dir, destination_dir, name_prefix)
@@ -18,6 +22,7 @@ abs_install(){
 		source_dir="$1"
 		destination_dir="$2"
 		prefix="$3"
+		file_type="$4" #used as a regex, for example if .sh is passed all files matching *.sh will be installed from the source_dir
 
 		prefix_of_package=""
 		if [ -z $prefix ];then
@@ -27,7 +32,7 @@ abs_install(){
 		fi
 
 		# Find all scripts in the source directory and its subdirectories
-		script_files=$(find "$source_dir" -type f -name "*.sh")
+		script_files=$(find "$source_dir" -type f -name "*${file_type}")
 
 
 		OLD_IFS="$IFS"
@@ -46,8 +51,9 @@ abs_install(){
 for src in $INSTALL_SOURCES;do
 		dir=$(echo $src | cut -d $INSTALL_SOURCES_DELIM -f 1)
 		prefix=$(echo $src | cut -d $INSTALL_SOURCES_DELIM -f 2)
+		file_type=$(echo $src | cut -d $INSTALL_SOURCES_DELIM -f 3)
 		echo installing $dir with prefix $prefix in $DESTINATION_DIR
-		abs_install "$dir" "$DESTINATION_DIR" "$prefix"
+		abs_install "$dir" "$DESTINATION_DIR" "$prefix" "$file_type"
 done
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -8,11 +8,13 @@ DESTINATION_DIR="/usr/bin"
 #list of tuples of (source_directory,prefix)
 INSTALL_SOURCES_DELIM=","
 
-#source_dir, prefix of installed file name, type of file (none for elf files)
+#each install source is in this format
+#source_dir,prefix of installed file name,type of file (none for elf files),is optional to install
+#if the 'is optional to install' is not zero length it should be interpreted as true, and it should be populated with 'Optional' keyword for better readability
 INSTALL_SOURCES="\
-Scripts${INSTALL_SOURCES_DELIM}${INSTALL_SOURCES_DELIM}.sh
-Libraries${INSTALL_SOURCES_DELIM}lib${INSTALL_SOURCES_DELIM}.sh
-Binary_Modules/bin/${INSTALL_SOURCES_DELIM}bin${INSTALL_SOURCES_DELIM}
+Scripts${INSTALL_SOURCES_DELIM}${INSTALL_SOURCES_DELIM}.sh${INSTALL_SOURCES_DELIM}
+Libraries${INSTALL_SOURCES_DELIM}lib${INSTALL_SOURCES_DELIM}.sh${INSTALL_SOURCES_DELIM}
+Binary_Modules/bin/${INSTALL_SOURCES_DELIM}bin${INSTALL_SOURCES_DELIM}${INSTALL_SOURCES_DELIM}Optional
 "
 
 #maybe this should be a library too!
@@ -52,6 +54,17 @@ for src in $INSTALL_SOURCES;do
 		dir=$(echo $src | cut -d $INSTALL_SOURCES_DELIM -f 1)
 		prefix=$(echo $src | cut -d $INSTALL_SOURCES_DELIM -f 2)
 		file_type=$(echo $src | cut -d $INSTALL_SOURCES_DELIM -f 3)
+		is_optional=$(echo $src | cut -d $INSTALL_SOURCES_DELIM -f 4)
+		confirm='y'
+		if [ -n "$is_optional" ];then
+			read -p "$dir is optional to install, install it? [Y/n]" -r confirm
+		fi
+
+		if [ "$confirm" = "n" ] || [ "$confirm" = "N" ];then
+			echo "will not install $dir"
+			continue
+		fi
+
 		echo installing $dir with prefix $prefix in $DESTINATION_DIR
 		abs_install "$dir" "$DESTINATION_DIR" "$prefix" "$file_type"
 done

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+ARCHITECTURES="\
+386
+amd64
+arm
+arm64
+"
+VERSION=$1
+if [ -z "$VERSION" ];then
+	echo version not provided
+	exit 1
+fi
+
+mkdir -p Release
+for arch in $ARCHITECTURES;do
+	rm -rf ./Binary_Modules/bin
+	(
+	cd Binary_Modules
+	GOARCH="$arch" bash build.sh
+ 	)
+	files_to_zip=$(find . -maxdepth 1 ! -name Release ! -name '.')
+	zip -r "Release/awesome-bash-scripts-${VERSION}-$arch.zip" $files_to_zip
+done


### PR DESCRIPTION
# New features
## abs.internet-problem-fixer
- **Interactive mode**: User won't be prompted for any input if the script is not in interactive mode.
- **Wifi support**: If the wifi requirements are met, the script will try to connect to each available wireless access point to reach the internet. 
# Bug fixes
- Fixed: `abs.lib.depcheck` wouldn't find executables in `/sbin` and `/usr/sbin` in debian.
- Fixed: Resolved some naming conflicts between `abs.logging` and `abs.internet-problem-fixer`.
# Improvements
## install.sh
- Install script now supports declaring install sources as optional.
- Install script now supports declaring file extensions for install sources (for example to grab all `.sh` files).
## abs.internet-problem-fixer
- Global read only variables are marked with `readonly` keyword.
- Local variables are marked with `local` keyword.
- Clarification in help.
- The script now has a list of interfaces that are excluded from any fix sequence by default.
	- This list includes: `lo,docker0,neko-tun,tun0`.
# Breaking changes
## abs.internet-problem-fixer
- Removed `-f` switch which was used to provide a filename for a list of excluded interfaces.
# Other
Added: `abs.bin.*` are compiled programs that enable scripts to perform more complex tasks, such as complex dbus method calls. Installing these modules are optional.
Added: `release.sh` makes release packages which have Binary_Modules compiled for 386, amd64, arm, arm64 architectures